### PR TITLE
Refactoring with MuData

### DIFF
--- a/milopy/plot.py
+++ b/milopy/plot.py
@@ -4,13 +4,14 @@ import numpy as np
 import anndata
 from typing import Union, Optional, Sequence, Any, Mapping, List, Tuple
 from anndata import AnnData
+from mudata import MuData
 
 import matplotlib.pyplot as plt
 import seaborn as sns
 
 
 def plot_nhood_graph(
-    adata: AnnData,
+    milo_mdata: MuData,
     alpha: float = 0.1,
     min_logFC: float = 0,
     min_size: int = 10,
@@ -23,7 +24,7 @@ def plot_nhood_graph(
 
     Params:
     -------
-    - adata: AnnData object
+    - milo_mdata: MuData object
     - alpha: significance threshold
     - min_logFC: minimum absolute log-Fold Change to show results (default: 0, show all significant neighbourhoods)
     - min_size: minimum size of nodes in visualization (default: 10)
@@ -31,7 +32,7 @@ def plot_nhood_graph(
     - title: plot title (default: 'DA log-Fold Change')
     - **kwargs: other arguments to pass to scanpy.pl.embedding
     '''
-    nhood_adata = adata.uns["nhood_adata"].copy()
+    nhood_adata = milo_mdata['samples'].T.copy()
 
     if "Nhood_size" not in nhood_adata.obs.columns:
         raise KeyError(
@@ -59,9 +60,8 @@ def plot_nhood_graph(
 
     sc.pl.embedding(nhood_adata, "X_milo_graph",
                     color="graph_color", cmap="RdBu_r",
-                    size=adata.uns["nhood_adata"].obs["Nhood_size"]*min_size,
+                    size=nhood_adata.obs["Nhood_size"]*min_size,
                     edges=plot_edges, neighbors_key="nhood",
-                    # edge_width =
                     sort_order=False,
                     frameon=False,
                     vmax=vmax, vmin=vmin,

--- a/milopy/tests/test_DA_nhoods.py
+++ b/milopy/tests/test_DA_nhoods.py
@@ -8,43 +8,72 @@ from milopy.core import DA_nhoods
 
 
 @pytest.fixture
-def anndata(seed=42):
+def milo_mdata(seed=42):
     adata = sc.datasets.pbmc68k_reduced()
     make_nhoods(adata)
 
     ## Simulate experimental condition ##
     np.random.seed(seed)
-    adata.obs["condition"] = np.random.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5,0.5])
+    adata.obs["condition"] = np.random.choice(
+        ["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5, 0.5])
     # we simulate differential abundance in NK cells
     DA_cells = adata.obs["louvain"] == "1"
-    adata.obs.loc[DA_cells, "condition"] = np.random.choice(["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2,0.8])
+    adata.obs.loc[DA_cells, "condition"] = np.random.choice(
+        ["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2, 0.8])
 
     ## Simulate replicates ##
-    adata.obs["replicate"] = np.random.choice(["R1", "R2", "R3"], size=adata.n_obs)
+    adata.obs["replicate"] = np.random.choice(
+        ["R1", "R2", "R3"], size=adata.n_obs)
     adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
-    count_nhoods(adata, sample_col="sample")
-    return adata
+    milo_mdata = count_nhoods(adata, sample_col="sample")
+    return milo_mdata
 
-def test_missing_covariate(anndata):
-    adata = anndata.copy() 
+
+def test_missing_covariate(milo_mdata):
+    milo_mdata = milo_mdata.copy()
     with pytest.raises(KeyError):
-        DA_nhoods(adata, design="~ciaone")
+        DA_nhoods(milo_mdata, design="~ciaone")
 
-def test_non_unique_covariate(anndata):
-    adata = anndata.copy() 
+
+def test_non_unique_covariate(milo_mdata):
+    milo_mdata = milo_mdata.copy()
     with pytest.raises(ValueError):
-        DA_nhoods(adata, design="~phase")
-        
-## Check that results make sense
-def test_pvalues(anndata):
-    adata = anndata.copy() 
-    DA_nhoods(adata, design="~condition")
-    nhood_adata = adata.uns["nhood_adata"]
-    min_p, max_p = nhood_adata.obs["PValue"].min(),nhood_adata.obs["PValue"].min()
+        DA_nhoods(milo_mdata, design="~phase")
+
+# Check that results make sense
+
+
+def test_pvalues(milo_mdata):
+    milo_mdata = milo_mdata.copy()
+    DA_nhoods(milo_mdata, design="~condition")
+    sample_adata = milo_mdata['samples'].copy()
+    min_p, max_p = sample_adata.var["PValue"].min(
+    ), sample_adata.var["PValue"].max()
     assert (min_p >= 0) & (max_p <= 1), "P-values are not between 0 and 1"
-    
-def test_fdr(anndata):
-    adata = anndata.copy() 
-    DA_nhoods(adata, design="~condition")
-    nhood_adata = adata.uns["nhood_adata"]
-    assert np.all(np.round(nhood_adata.obs["PValue"], 10) <= np.round(nhood_adata.obs["SpatialFDR"], 10)), "FDR is higher than uncorrected P-values"
+
+
+def test_fdr(milo_mdata):
+    milo_mdata = milo_mdata.copy()
+    DA_nhoods(milo_mdata, design="~condition")
+    sample_adata = milo_mdata['samples'].copy()
+    assert np.all(np.round(sample_adata.var["PValue"], 10) <= np.round(
+        sample_adata.var["SpatialFDR"], 10)), "FDR is higher than uncorrected P-values"
+
+# Test specifying contrasts
+
+
+def test_default_contrast(milo_mdata):
+    milo_mdata = milo_mdata.copy()
+    adata = milo_mdata['cells'].copy()
+    adata.obs['condition'] = adata.obs['condition'].astype(
+        'category').cat.reorder_categories(['ConditionA', 'ConditionB'])
+    DA_nhoods(milo_mdata, design='~condition')
+    default_results = milo_mdata['samples'].var.copy()
+    DA_nhoods(milo_mdata, design='~condition',
+              model_contrasts='conditionConditionB-conditionConditionA')
+    contr_results = milo_mdata['samples'].var.copy()
+
+    assert np.corrcoef(contr_results['SpatialFDR'], default_results['SpatialFDR'])[
+        0, 1] > 0.99
+    assert np.corrcoef(contr_results['logFC'],
+                       default_results['logFC'])[0, 1] > 0.99

--- a/milopy/tests/test_add_nhood_expression.py
+++ b/milopy/tests/test_add_nhood_expression.py
@@ -1,0 +1,56 @@
+import pytest
+import scanpy as sc
+import numpy as np
+from milopy.core import make_nhoods, count_nhoods
+from milopy.utils import add_nhood_expression
+
+
+@pytest.fixture
+def mdata(seed=42):
+    adata = sc.datasets.pbmc3k()
+    sc.pp.normalize_per_cell(adata)
+    sc.pp.log1p(adata)
+    sc.pp.highly_variable_genes(adata)
+    sc.pp.pca(adata)
+    sc.pp.neighbors(adata)
+    sc.tl.leiden(adata)
+    make_nhoods(adata)
+
+    ## Simulate experimental condition ##
+    np.random.seed(seed)
+    adata.obs["condition"] = np.random.choice(
+        ["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.2, 0.8])
+    # we simulate differential abundance in NK cells
+    DA_cells = adata.obs["leiden"] == "1"
+    adata.obs.loc[DA_cells, "condition"] = np.random.choice(
+        ["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2, 0.8])
+
+    ## Simulate replicates ##
+    adata.obs["replicate"] = np.random.choice(
+        ["R1", "R2", "R3"], size=adata.n_obs)
+    adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
+    milo_mdata = count_nhoods(adata, sample_col="sample")
+    return milo_mdata
+
+## Test that dimensions are correct ##
+
+
+def test_nhood_mean_range(mdata):
+    milo_mdata = mdata.copy()
+    add_nhood_expression(milo_mdata)
+    assert milo_mdata['samples'].varm['expr'].shape[1] == milo_mdata['cells'].n_vars
+
+## Test the result is the mean ##
+
+
+def test_nhood_mean_range(mdata):
+    milo_mdata = mdata.copy()
+    add_nhood_expression(milo_mdata)
+    nhood_ix = 10
+    nhood_gex = milo_mdata['samples'].varm['expr'][nhood_ix,
+                                                   :].toarray().ravel()
+    nhood_cells = milo_mdata['cells'].obs_names[milo_mdata['cells'].obsm['nhoods']
+                                                [:, nhood_ix].toarray().ravel() == 1]
+    mean_gex = np.array(milo_mdata['cells']
+                        [nhood_cells].X.mean(axis=0)).ravel()
+    nhood_gex == pytest.approx(mean_gex, 0.0001)

--- a/milopy/tests/test_annotate_nhoods.py
+++ b/milopy/tests/test_annotate_nhoods.py
@@ -6,9 +6,9 @@ from milopy.utils import annotate_nhoods, annotate_nhoods_continuous
 
 
 @pytest.fixture
-def adata(seed=42):
-    adata = prep_nhood_matrix(seed)
-    return adata
+def milo_mdata(seed=42):
+    milo_mdata = prep_nhood_matrix(seed)
+    return milo_mdata
 
 
 def prep_nhood_matrix(seed):
@@ -28,30 +28,30 @@ def prep_nhood_matrix(seed):
     adata.obs["replicate"] = np.random.choice(
         ["R1", "R2", "R3"], size=adata.n_obs)
     adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
-    count_nhoods(adata, sample_col='sample')
-    return adata
+    milo_mdata = count_nhoods(adata, sample_col='sample')
+    return milo_mdata
 
 # --- Annotate continuous tests ---
 
 # Test that mean values are within the expected range
 
 
-def test_nhood_mean_range(adata):
-    annotate_nhoods_continuous(adata, anno_col='S_score')
-    assert adata.uns['nhood_adata'].obs['nhood_S_score'].max(
-    ) < adata.obs['S_score'].max()
-    assert adata.uns['nhood_adata'].obs['nhood_S_score'].min(
-    ) > adata.obs['S_score'].min()
+def test_nhood_mean_range(milo_mdata):
+    annotate_nhoods_continuous(milo_mdata, anno_col='S_score')
+    assert milo_mdata['samples'].var['nhood_S_score'].max(
+    ) < milo_mdata['cells'].obs['S_score'].max()
+    assert milo_mdata['samples'].var['nhood_S_score'].min(
+    ) > milo_mdata['cells'].obs['S_score'].min()
 
 # Test that value corresponds to mean
 
 
-def test_correct_mean(adata):
-    annotate_nhoods_continuous(adata, anno_col='S_score')
-    i = np.random.choice(np.arange(adata.uns['nhood_adata'].n_obs))
-    mean_val_nhood = adata.obs[adata.obsm['nhoods']
-                               [:, i].toarray() == 1]['S_score'].mean()
-    assert adata.uns['nhood_adata'].obs['nhood_S_score'][i] == pytest.approx(
+def test_correct_mean(milo_mdata):
+    annotate_nhoods_continuous(milo_mdata, anno_col='S_score')
+    i = np.random.choice(np.arange(milo_mdata['samples'].n_obs))
+    mean_val_nhood = milo_mdata['cells'].obs[milo_mdata['cells'].obsm['nhoods']
+                                             [:, i].toarray() == 1]['S_score'].mean()
+    assert milo_mdata['samples'].var['nhood_S_score'][i] == pytest.approx(
         mean_val_nhood, 0.0001)
 
 
@@ -59,15 +59,14 @@ def test_correct_mean(adata):
 
 # Test that label fractions are in the correct range
 
-
-def test_nhood_annotation_frac_range(adata):
-    annotate_nhoods(adata, anno_col='louvain')
-    assert adata.uns['nhood_adata'].obs['nhood_annotation_frac'].max() <= 1.0
-    assert adata.uns['nhood_adata'].obs['nhood_annotation_frac'].min() >= 0.0
+def test_nhood_annotation_frac_range(milo_mdata):
+    annotate_nhoods(milo_mdata, anno_col='louvain')
+    assert milo_mdata['samples'].var['nhood_annotation_frac'].max() <= 1.0
+    assert milo_mdata['samples'].var['nhood_annotation_frac'].min() >= 0.0
 
 # Test continuous covariate gives error
 
 
-def test_nhood_annotation_cont_gives_error(adata):
+def test_nhood_annotation_cont_gives_error(milo_mdata):
     with pytest.raises(ValueError):
-        annotate_nhoods(adata, anno_col='S_score')
+        annotate_nhoods(milo_mdata, anno_col='S_score')

--- a/milopy/tests/test_count_nhoods.py
+++ b/milopy/tests/test_count_nhoods.py
@@ -4,40 +4,44 @@ import numpy as np
 import pandas as pd
 from milopy.core import make_nhoods
 from milopy.core import count_nhoods
-       
+
 adata = sc.datasets.pbmc68k_reduced()
 make_nhoods(adata)
-    
-def test_sample_values():
-    ## Extract cells of one nhood
-    nh=1
-    sample_col="phase"
-    count_nhoods(adata, sample_col=sample_col)
-    nh_cells = adata.obsm["nhoods"][:,nh].nonzero()[0]
 
-    ## Value count the sample composition
+
+def test_sample_values():
+    # Extract cells of one nhood
+    nh = 1
+    sample_col = "phase"
+    milo_mdata = count_nhoods(adata, sample_col=sample_col)
+    nh_cells = adata.obsm["nhoods"][:, nh].nonzero()[0]
+
+    # Value count the sample composition
     top_a = adata.obs.iloc[nh_cells].value_counts(sample_col).values.ravel()
 
-    ## Check it matches the one calculated
-    df = pd.DataFrame(adata.uns["nhood_adata"].X[nh,:].toarray()).T
-    df.index = adata.uns["nhood_adata"].var_names
+    # Check it matches the one calculated
+    sample_adata = milo_mdata['samples']
+    df = pd.DataFrame(sample_adata.X.T[nh, :].toarray()).T
+    df.index = sample_adata.obs_names
     top_b = df.sort_values(0, ascending=False).values.ravel()
-    assert all((top_b - top_a) == 0), 'The counts for samples in adata.uns["nhood_adata"] does not match'
-    
-def test_sample_order():    
-    ## Extract cells of one nhood
-    nh=1
-    sample_col="phase"
-    count_nhoods(adata, sample_col=sample_col)
-    nh_cells = adata.obsm["nhoods"][:,nh].nonzero()[0]
+    assert all((top_b - top_a) ==
+               0), 'The counts for samples in milo_mdata["samples"] does not match'
 
-    ## Value count the sample composition
+
+def test_sample_order():
+    # Extract cells of one nhood
+    nh = 1
+    sample_col = "phase"
+    milo_mdata = count_nhoods(adata, sample_col=sample_col)
+    nh_cells = adata.obsm["nhoods"][:, nh].nonzero()[0]
+
+    # Value count the sample composition
     top_a = adata.obs.iloc[nh_cells].value_counts(sample_col).index[0]
 
-    ## Check it matches the one calculated
-    df = pd.DataFrame(adata.uns["nhood_adata"].X[nh,:].toarray()).T
-    df.index = adata.uns["nhood_adata"].var_names
+    # Check it matches the one calculated
+    sample_adata = milo_mdata['samples']
+    df = pd.DataFrame(sample_adata.X.T[nh, :].toarray()).T
+    df.index = sample_adata.obs_names
     top_b = df.sort_values(0, ascending=False).index[0]
 
-    assert top_a==top_b, 'The order of samples in adata.uns["nhood_adata"] does not match'
- 
+    assert top_a == top_b, 'The order of samples in milo_mdata["samples"] does not match'

--- a/milopy/utils.py
+++ b/milopy/utils.py
@@ -5,6 +5,7 @@ import scipy.sparse
 import anndata
 from typing import Union, Optional, Sequence, Any, Mapping, List, Tuple
 from anndata import AnnData
+from mudata import MuData
 from scipy.sparse import csr_matrix
 import random
 
@@ -12,28 +13,28 @@ import random
 
 
 def add_nhood_expression(
-    adata: AnnData,
+    milo_mdata: MuData,
     layer: str = None,
 ):
     '''
-    Calculates the mean expression in neighbourhoods of each feature in `adata.X` or
-    `adata.layers[layer]` (if layer is not None).
+    Calculates the mean expression in neighbourhoods of each feature in `milo_mdata['cells'].X` or
+    `milo_mdata['cells'][layer]` (if layer is not None).
 
     Params:
     -------
-    - adata: AnnData object
-    - layer: which data layer to use as expression matrix (default: None, uses `adata.X`)
+    - milo_mdata: MuData object
+    - layer: which data layer to use as expression matrix (default: None, uses `milo_mdata['cells'].X`)
 
     Returns:
     -------
-    Updates adata in place to store the matrix of average expression in each neighbourhood in `adata.uns["nhood_adata"].obsm['expr']`
+    Updates adata in place to store the matrix of average expression in each neighbourhood in `milo_mdata['samples'].varm['expr']`
     '''
     try:
-        nhood_adata = adata.uns["nhood_adata"]
+        sample_adata = milo_mdata['samples']
     except KeyError:
-        raise KeyError(
-            'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.count_nhoods(adata)'
-        )
+        raise ValueError(
+            "milo_mdata should be a MuData object with two slots: 'cells' and 'samples' - please run milopy.count_nhoods(adata) first")
+    adata = milo_mdata['cells']
 
     # Get gene expression matrix
     if layer is None:
@@ -46,73 +47,76 @@ def add_nhood_expression(
     # Aggregate over nhoods -- taking the mean
     nhoods_X = X.T.dot(adata.obsm["nhoods"])
     nhoods_X = csr_matrix(nhoods_X / adata.obsm["nhoods"].toarray().sum(0))
-    adata.uns["nhood_adata"].obsm[expr_id] = nhoods_X.T
+    sample_adata.varm[expr_id] = nhoods_X.T
 
 
 ## -- NHOOD GRAPH -- ##
 
-def build_nhood_graph(adata: AnnData,
+def build_nhood_graph(milo_mdata: MuData,
                       basis: str = "X_umap"):
     '''
     Build graph of neighbourhoods used for visualization of DA results
 
     Params:
     -------
-    - adata: AnnData object
+    - milo_mdata: MuData object
     - basis: string indicating the name of the obsm basis to use to use for layout of neighbourhoods (key in `adata.obsm`)
     '''
-    # Add embedding positions
-    adata.uns["nhood_adata"].obsm["X_milo_graph"] = adata[adata.obs["nhood_ixs_refined"] == 1].obsm[basis]
+    adata = milo_mdata['cells']
+    # # Add embedding positions
+    milo_mdata['samples'].varm["X_milo_graph"] = adata[adata.obs["nhood_ixs_refined"] == 1].obsm[basis]
     # Add nhood size
-    adata.uns["nhood_adata"].obs["Nhood_size"] = np.array(
+    milo_mdata['samples'].var["Nhood_size"] = np.array(
         adata.obsm["nhoods"].sum(0)).flatten()
     # Add adjacency graph
-    adata.uns["nhood_adata"].obsp["nhood_connectivities"] = adata.obsm["nhoods"].T.dot(
+    milo_mdata['samples'].varp["nhood_connectivities"] = adata.obsm["nhoods"].T.dot(
         adata.obsm["nhoods"])
-    adata.uns["nhood_adata"].uns["nhood"] = {
+    milo_mdata['samples'].varp['nhood_connectivities'].setdiag(0)
+    milo_mdata['samples'].varp['nhood_connectivities'].eliminate_zeros()
+    milo_mdata['samples'].uns["nhood"] = {
         "connectivities_key": "nhood_connectivities", "distances_key": ""}
 
 ## -- UTILS --- ##
 
 
 def add_covariate_to_nhoods_var(
-        adata: AnnData,
+        milo_mdata: MuData,
         new_covariates: List[str]):
     '''
     Add covariate from adata.obs to adata.uns["nhood_adata"].var
     '''
     try:
-        nhood_adata = adata.uns["nhood_adata"].copy()
+        sample_adata = milo_mdata['samples']
     except KeyError:
-        raise KeyError(
-            'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.count_nhoods(adata)'
-        )
+        raise ValueError(
+            "milo_mdata should be a MuData object with two slots: 'cells' and 'samples' - please run milopy.count_nhoods(adata) first")
+    adata = milo_mdata['cells']
 
-    sample_col = nhood_adata.uns["sample_col"]
+    sample_col = sample_adata.uns["sample_col"]
     covariates = list(set(
-        nhood_adata.var.columns[nhood_adata.var.columns != sample_col].tolist() + new_covariates))
+        sample_adata.obs.columns[sample_adata.obs.columns != sample_col].tolist() + new_covariates))
     try:
-        nhoods_var = adata.obs[covariates + [sample_col]].drop_duplicates()
+        sample_obs = adata.obs[covariates + [sample_col]].drop_duplicates()
     except KeyError:
         missing_cov = [
-            x for x in covariates if x not in nhood_adata.var.columns]
+            x for x in covariates if x not in sample_adata.obs.columns]
         raise KeyError(
             'Covariates {c} are not columns in adata.obs'.format(
                 c=" ".join(missing_cov))
         )
-    nhoods_var = nhoods_var[covariates + [sample_col]].astype("str")
-    nhoods_var.index = nhoods_var[sample_col]
+    sample_obs = sample_obs[covariates + [sample_col]].astype("str")
+    sample_obs.index = sample_obs[sample_col]
     try:
-        assert nhoods_var.loc[nhood_adata.var_names].shape[0] == len(
-            nhood_adata.var_names)
+        assert sample_obs.loc[sample_adata.obs_names].shape[0] == len(
+            sample_adata.obs_names)
     except:
         raise ValueError(
             "Covariates cannot be unambiguously assigned to each sample -- each sample value should match a single covariate value")
-    nhood_adata.var = nhoods_var.loc[nhood_adata.var_names]
-    adata.uns["nhood_adata"] = nhood_adata
+    sample_adata.obs = sample_obs.loc[sample_adata.obs_names]
+    # adata.uns["nhood_adata"] = nhood_adata
 
 
-def annotate_nhoods(adata: AnnData,
+def annotate_nhoods(milo_mdata: MuData,
                     anno_col: str):
     '''
     Assigns a categorical label to neighbourhoods, based on the most frequent label
@@ -121,23 +125,23 @@ def annotate_nhoods(adata: AnnData,
 
     Params:
     -------
-    - adata: AnnData object with adata.uns["nhood_adata"]
+    - milo_mdata: MuData object 
     - anno_col: string indicating column in adata.obs containing the cell annotations to use for nhood labelling
 
     Returns:
     --------
     None. Adds in place:
-    - `adata.uns["nhood_adata"].obs["nhood_annotation"]`: assigning a label to each nhood
-    - `adata.uns["nhood_adata"].obs["nhood_annotation_frac"]` stores the fraciton of cells in the neighbourhood with the assigned label
-    - `adata.uns["nhood_adata"].obsm['frac_annotation']`: stores the fraction of cells from each label in each nhood
-    - `adata.uns["nhood_adata"].uns["annotation_labels"]`: stores the column names for `adata.uns["nhood_adata"].obsm['frac_annotation']`
+    - `milo_mdata['samples'].var["nhood_annotation"]`: assigning a label to each nhood
+    - `milo_mdata['samples'].var["nhood_annotation_frac"]` stores the fraciton of cells in the neighbourhood with the assigned label
+    - `milo_mdata['samples'].varm['frac_annotation']`: stores the fraction of cells from each label in each nhood
+    - `milo_mdata['samples'].uns["annotation_labels"]`: stores the column names for `milo_mdata['samples'].varm['frac_annotation']`
     '''
     try:
-        nhood_adata = adata.uns["nhood_adata"]
+        sample_adata = milo_mdata['samples']
     except KeyError:
-        raise KeyError(
-            'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.make_nhoods_adata(adata)'
-        )
+        raise ValueError(
+            "milo_mdata should be a MuData object with two slots: 'cells' and 'samples' - please run milopy.count_nhoods(adata) first")
+    adata = milo_mdata['cells']
 
     # Check value is not numeric
     if pd.api.types.is_numeric_dtype(adata.obs[anno_col]):
@@ -151,17 +155,17 @@ def annotate_nhoods(adata: AnnData,
 
     anno_frac = pd.DataFrame(anno_frac,
                              columns=anno_dummies.columns,
-                             index=adata.uns["nhood_adata"].obs_names
+                             index=milo_mdata['samples'].var_names
                              )
-    adata.uns["nhood_adata"].obsm["frac_annotation"] = anno_frac.values
-    adata.uns["nhood_adata"].uns["annotation_labels"] = anno_frac.columns
-    adata.uns["nhood_adata"].uns["annotation_obs"] = anno_col
-    adata.uns["nhood_adata"].obs["nhood_annotation"] = anno_frac.idxmax(1)
-    adata.uns["nhood_adata"].obs["nhood_annotation_frac"] = anno_frac.max(1)
+    milo_mdata['samples'].varm["frac_annotation"] = anno_frac.values
+    milo_mdata['samples'].uns["annotation_labels"] = anno_frac.columns
+    milo_mdata['samples'].uns["annotation_obs"] = anno_col
+    milo_mdata['samples'].var["nhood_annotation"] = anno_frac.idxmax(1)
+    milo_mdata['samples'].var["nhood_annotation_frac"] = anno_frac.max(1)
 
 
 def annotate_nhoods_continuous(
-        adata: AnnData,
+        milo_mdata: MuData,
         anno_col: str):
     '''
     Assigns a continuous value to neighbourhoods, based on mean cell level covariate stored in adata.obs. 
@@ -169,20 +173,20 @@ def annotate_nhoods_continuous(
 
     Params:
     -------
-    - adata: AnnData object with adata.uns["nhood_adata"]
+    - adata: MuData object
     - anno_col: string indicating column in adata.obs containing the cell annotations to use for nhood labelling
 
     Returns:
     --------
     None. Adds in place:
-    - `adata.uns["nhood_adata"].obs["nhood_{anno_col}"]`: assigning a continuous value to each nhood
+    - `milo_mdata['samples'].var["nhood_{anno_col}"]`: assigning a continuous value to each nhood
     '''
     try:
-        nhood_adata = adata.uns["nhood_adata"]
+        sample_adata = milo_mdata['samples']
     except KeyError:
-        raise KeyError(
-            'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.count_nhoods(adata)'
-        )
+        raise ValueError(
+            "milo_mdata should be a MuData object with two slots: 'cells' and 'samples' - please run milopy.count_nhoods(adata) first")
+    adata = milo_mdata['cells']
 
     # Check value is not categorical
     if not pd.api.types.is_numeric_dtype(adata.obs[anno_col]):
@@ -194,60 +198,60 @@ def annotate_nhoods_continuous(
 
     mean_anno_val = anno_val.toarray()/np.array(adata.obsm["nhoods"].T.sum(1))
 
-    adata.uns["nhood_adata"].obs[f"nhood_{anno_col}"] = mean_anno_val
+    milo_mdata['samples'].var[f"nhood_{anno_col}"] = mean_anno_val
 
 
-## -- I/O -- ##
-def write_milo_adata(adata: AnnData,
-                     filepath: str,
-                     **kwargs):
-    '''
-    Save anndata objects after Milo analysis
+# ## -- I/O -- ##
+# def write_milo_adata(adata: AnnData,
+#                      filepath: str,
+#                      **kwargs):
+#     '''
+#     Save anndata objects after Milo analysis
 
-    Params:
-    -----
-    - adata: AnnData object with adata.uns["nhood_adata"]
-    - filepath: path to h5ad file to save
-    - **kwargs: arguments passed to scanpy.write_h5ad 
+#     Params:
+#     -----
+#     - adata: AnnData object with adata.uns["nhood_adata"]
+#     - filepath: path to h5ad file to save
+#     - **kwargs: arguments passed to scanpy.write_h5ad
 
-    Returns:
-    -------
-    None, saves 2 AnnData objects in h5ad format. The cell x gene AnnData is saved in filepath.
-    The nhood x sample AnnData is saved in a separate object (location is stored in adata.uns['nhood_adata_filepath'])
-    '''
-    nhood_filepath = filepath.split('.h5ad')[0] + ".nhood_adata.h5ad"
-    adata.uns['nhood_adata_filepath'] = nhood_filepath
-    try:
-        if 'annotation_labels' in adata.uns['nhood_adata'].uns.keys():
-            adata.uns['nhood_adata'].uns['annotation_labels'] = adata.uns['nhood_adata'].uns['annotation_labels'].tolist()
-    except KeyError:
-        raise KeyError(
-            'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.make_nhoods_adata(adata)')
-    nhood_adata = adata.uns["nhood_adata"].copy()
-    nhood_adata.write_h5ad(nhood_filepath, **kwargs)
-    del adata.uns["nhood_adata"]
-    adata.write_h5ad(filepath, **kwargs)
+#     Returns:
+#     -------
+#     None, saves 2 AnnData objects in h5ad format. The cell x gene AnnData is saved in filepath.
+#     The nhood x sample AnnData is saved in a separate object (location is stored in adata.uns['nhood_adata_filepath'])
+#     '''
+#     nhood_filepath = filepath.split('.h5ad')[0] + ".nhood_adata.h5ad"
+#     adata.uns['nhood_adata_filepath'] = nhood_filepath
+#     try:
+#         if 'annotation_labels' in adata.uns['nhood_adata'].uns.keys():
+#             adata.uns['nhood_adata'].uns['annotation_labels'] = adata.uns['nhood_adata'].uns['annotation_labels'].tolist()
+#     except KeyError:
+#         raise KeyError(
+#             'Cannot find "nhood_adata" slot in adata.uns -- please run milopy.make_nhoods_adata(adata)')
+#     nhood_adata = adata.uns["nhood_adata"].copy()
+#     nhood_adata.write_h5ad(nhood_filepath, **kwargs)
+#     del adata.uns["nhood_adata"]
+#     adata.write_h5ad(filepath, **kwargs)
 
 
-def read_milo_adata(
-        filepath: str,
-        **kwargs) -> AnnData:
-    '''
-    Read AnnData objects stored after Milo analysis
+# def read_milo_adata(
+#         filepath: str,
+#         **kwargs) -> AnnData:
+#     '''
+#     Read AnnData objects stored after Milo analysis
 
-    Params:
-    ------
-    - filepath: path to h5ad file storing cell x gene AnnData object
-    - **kwargs: additional arguments passed to scanpy.read_h5ad
+#     Params:
+#     ------
+#     - filepath: path to h5ad file storing cell x gene AnnData object
+#     - **kwargs: additional arguments passed to scanpy.read_h5ad
 
-    Returns:
-    -------
-    - AnnData object storing milo slots (adata.obsm['nhoods'], adata.uns['nhood_adata'])
-    '''
-    adata = sc.read_h5ad(filepath, **kwargs)
-    try:
-        nhood_filepath = adata.uns['nhood_adata_filepath']
-    except:
-        raise KeyError('No nhood_adata_file associated to adata')
-    adata.uns["nhood_adata"] = sc.read_h5ad(nhood_filepath, **kwargs)
-    return(adata)
+#     Returns:
+#     -------
+#     - AnnData object storing milo slots (adata.obsm['nhoods'], adata.uns['nhood_adata'])
+#     '''
+#     adata = sc.read_h5ad(filepath, **kwargs)
+#     try:
+#         nhood_filepath = adata.uns['nhood_adata_filepath']
+#     except:
+#         raise KeyError('No nhood_adata_file associated to adata')
+#     adata.uns["nhood_adata"] = sc.read_h5ad(nhood_filepath, **kwargs)
+#     return(adata)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 scanpy
 pandas
 anndata
+mudata
 numpy
 rpy2 >= 3.3.5
 scipy

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='milopy',
-      version='0.0.99',
+      version='0.1.0',
       description='python implementation of miloR for differential abundance analysis in single-cell datasets',
       url='https://github.com/emdann/milopy',
       author='Emma Dann',
@@ -12,6 +12,7 @@ setup(name='milopy',
           "pandas",
           "anndata",
           "scanpy>=1.6.0",
+          "mudata>=0.2.0",
           "scipy",
           "numpy",
           "matplotlib",


### PR DESCRIPTION
The original cell-level AnnData object and the sample x nhoods AnnData are stored in a common MuData object with `.mod` `cells` and `samples`. Samples are in `mdata["samples"].obs` and nhoods are in `mdata["samples"].var`.

**Notes**
- The `make_nhoods` function is left as is, the MuData object gets created by `count_nhoods`. The rationale is that here samples are not taken into consideration yet.
- This MuData doesn't follow any of the possible options for `axis` as defined in [MuData documentation](https://mudata.readthedocs.io/en/latest/notebooks/axes.html), since neither `.obs` nor `.var` are shared between cells and samples

**To do**
- [ ] Update documentation
- [ ] Update vignette
- [ ] ?